### PR TITLE
Load ConfigNode from GameDatabase

### DIFF
--- a/FillItUp/Settings/IgnoredResourcesConfigNode.cs
+++ b/FillItUp/Settings/IgnoredResourcesConfigNode.cs
@@ -55,23 +55,19 @@ namespace FillItUp
 
         public static IgnoredResourcesConfigNode LoadOrCreate()
         {
-            string fileFullPath = GetEnsuredConfigPath();
+            ConfigNode internalNode = new ConfigNode();
 
-            ConfigNode file = ConfigNode.Load(fileFullPath);
-            ConfigNode internalNode = null;
+            //We need the ConfigNode after MM could do some magic
+            ConfigNode[] config = GameDatabase.Instance.GetConfigNodes(NODE);
 
-            if (file != null)
+            if (config.Length == 0)
             {
-                if (file.HasNode(NODE))
-                    internalNode = file.GetNode(NODE);
+                Debug.Log($"ConfigNode {NODE} does not exist");
             }
-
-            if (internalNode == null)
-            {
-                internalNode = new ConfigNode();
-
+            else
+            {                
+                internalNode = config[0];
             }
-
 
             if (!internalNode.HasValue(IGNORED))
             {
@@ -85,13 +81,13 @@ namespace FillItUp
             return new IgnoredResourcesConfigNode(internalNode);
         }
 
+        //AFAIK, it is not necessayry anymore
+        //private static string GetEnsuredConfigPath()
+        //{
+        //    string path = "GameData/FillItUp/IgnoredResources.cfg";
 
-        private static string GetEnsuredConfigPath()
-        {
-            string path = "GameData/FillItUp/IgnoredResources.cfg";
-
-            return path;
-        }
+        //    return path;
+        //}
 
 #endregion
     }


### PR DESCRIPTION
Some changes to load the FILLITUP ConfigNode from the GameDatabase instead of the config file, so MM patches actually have an effect.

This is the first time I've done anything with ConfigNodes, please check the code carefully.
I tested the code with:
-No ConfigNode
-Empty ConfigNode
-Default ConfigNode
-Default ConfigNode + custom MM patch

Got no exceptions and everything worked like expected.