### PR TITLE
Resource locking won't unlock

### DIFF
--- a/FillItUp/Settings/FillItUpConfigNode.cs
+++ b/FillItUp/Settings/FillItUpConfigNode.cs
@@ -103,7 +103,7 @@ namespace FillItUp
                 return;
             string s = "";
             foreach (var s1 in value)
-            {;
+            {
                 if (s1.Value.stage == StageRes.ALLSTAGES)
                 {
                     if (s != "")

--- a/FillItUp/Settings/FillItUpConfigNode.cs
+++ b/FillItUp/Settings/FillItUpConfigNode.cs
@@ -113,7 +113,6 @@ namespace FillItUp
                 }
             }
             _node.SetValue(RUNTIMELOCKED, s, true);
-            LoadRuntimeLockedResources(true);
         }
 
         public Dictionary<string, StageRes> RuntimeLockedResources

--- a/FillItUp/Settings/FillItUpConfigNode.cs
+++ b/FillItUp/Settings/FillItUpConfigNode.cs
@@ -163,7 +163,6 @@ namespace FillItUp
             {
                 sr = new StageRes(stage, s);
                 runtimeLockedResources.Remove(sr.Key);
-                LoadRuntimeLockedResources(false);
                 LockedToNode(runtimeLockedResources);
             }
         }


### PR DESCRIPTION
Hello.

I had two issues with locking/unlocking resources:

In the all-stage view, I could lock resources but not unlock them. Toggle buttons would not toggle or suddenly reset to on and there was a message about duplicate dictionary keys in the log.

In the single stage view, locking resources wouldn't work at all. The toggle button just didn't toggle.

If I understand the code right, I think this is what happens:

- when a resource was removed from the list by RemoveRuntimeLockedResource(), its call to LoadRuntimeLockedResources() would just re-add it because the config node would still contain the unchanged list. A subsequent call to LoadRuntimeLockedResources() within LockedToNode() then led to duplicate dictionary key exceptions (although I'm not quite sure how, if "init" is set to true)

- single stage locking didn't work properly because although the resource was added to the stage list by AddRuntimeLockedResource(), it would be removed again by LockedToNode() only saving the list for ALLSTAGES and then reloading runtimeLockedResources from just this config node. Removing the call to LoadRuntimeLockedResources() keeps the list intact.

Removing both calls fixes the issue for me and I didn't notice any ill side-effects so far.
